### PR TITLE
Fixes dart2js warning about dead code

### DIFF
--- a/lib/src/protobuf/generated_message.dart
+++ b/lib/src/protobuf/generated_message.dart
@@ -662,10 +662,8 @@ abstract class GeneratedMessage {
         // Use strings for 64-bit integers which cannot fit in doubles.
         if (MIN_JSON_INT <= fieldValue && fieldValue <= MAX_JSON_INT) {
           return fieldValue.toInt();
-        } else {
-          return fieldValue.toString();
         }
-        break;
+        return fieldValue.toString();
       case _GROUP_BIT:
       case _MESSAGE_BIT:
         return fieldValue._toMap();


### PR DESCRIPTION
Hi,

dart2js currently (correctly) complains about the "break;" on line 668 being dead code. This minor change should remove the warning while still keeping all cases ending with a break or return (which is my guess for the motivation behind adding the "break" there in the first place).

This is helpful for those who like to keep their builds warning-free, or who treat warnings as erros. Cheers!
